### PR TITLE
uplink.py: define "network_name" var before using

### DIFF
--- a/uplink.py
+++ b/uplink.py
@@ -110,8 +110,8 @@ if __name__ == '__main__':
 
     # Iterate through all other devices
     for device in devices:
-        print('Looking into network ' + network_name)
         network_name = get_network_name(device['networkId'], networks)
+        print('Looking into network ' + network_name)
         device_name = json.loads(session.get('https://api.meraki.com/api/v0/networks/' + device['networkId'] + '/devices/' + device['serial'], headers=headers).text)['name']
         try:
             print('Found device ' + device_name)


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Before this commit, python would error with:

```
$ python3 ./uplink.py
Traceback (most recent call last):
  File "./uplink.py", line 113, in <module>
    print('Looking into network ' + network_name)
NameError: name 'network_name' is not defined
```