### PR TITLE
Org pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Files contained in this repository:
 
 **autovpn_tunnel_count.py:** Counts how many VPN tunnels are consumed per network for establishing Auto VPN connectivity to peers.
 
-**bssid.py:** Pulls the BSSID of the enabled SSID in a specified network, and puts them in a CSV.
+**bssid.py:** Pulls the BSSID of the enabled SSID for all networks in an organization and writes them to a CSV per network. If you have access to more than one organization, it will ask you to input the organizatin id you want to run against..
 
 **checksubnets.py:** This is a script to check if the LAN IPs (management addresses) of all access points in one or more organizations belong to specific IPv4 subnets. The purpose of the script is to find access points with misconfigured management addresses or VLANs, which may cause issues with 802.1x authentications. The output can be displayed on screen or sent as an email report.
 

--- a/bssid.py
+++ b/bssid.py
@@ -54,12 +54,11 @@ def getOrgs():
         for dic in orgs:
             org_list[dic['id']] = dic['name']
         orgID = input(f'Please type in the number of the Organization name '
-                      f'that you would like to query {json.dumps(org_list, indent=4)}' "\n")
+            f'that you would like to query {json.dumps(org_list, indent=4)}' "\n")
         orgName = org_list.get(orgID)
         loc2 = loc / orgName
         getlocation2(loc2)
         getNetworks(orgID, orgName)
-
 
 
 def getNetworks(orgID, orgName):
@@ -74,15 +73,13 @@ def getNetworks(orgID, orgName):
         getAP(net_id, net_name, orgName)
 
 
-
-
 def getAP(net_id, net_name, orgName):
     devices = dashboard.networks.getNetworkDevices(net_id)
     ap_list = {}
     for dic in devices:
         model = dic['model'][:2]
         if model == 'MR' or model == 'CW':
-            if dic.get('name') == None:
+            if dic.get('name') is None:
                 ap_list[dic['mac']] = dic['serial']
             else:
                 ap_list[dic['name']] = dic['serial']

--- a/bssid.py
+++ b/bssid.py
@@ -23,58 +23,74 @@ import sys
 from pathlib import Path
 import json
 
-ap_list = {}
-bssid_list = []
+net_list = {}
 p = Path.home()
 loc = p / 'Documents' / 'BSSID'
 
 dashboard = meraki.DashboardAPI(suppress_logging=True)
 
 
-def getLocation():
+def getLocation1():
     if not Path.is_dir(loc):
         Path.mkdir(loc)
 
 
-def getOrgs(net_name):
+def getlocation2(loc2):
+    if not Path.is_dir(loc2):
+        Path.mkdir(loc2)
+
+
+def getOrgs():
     orgs = dashboard.organizations.getOrganizations()
     if len(orgs) == 1:
         for dic in orgs:
             orgID = dic['id']
-            getNetworks(orgID, net_name)
+            orgName = dic['name']
+            loc2 = loc / orgName
+            getlocation2(loc2)
+            getNetworks(orgID, orgName)
     else:
         org_list = {}
         for dic in orgs:
-            org_list[dic['name']] = dic['id']
-        orgID = input(
-            f'Please type in the number of the Organization name that you would like to query{json.dumps(org_list, indent = 4)}' "\n")
-        getNetworks(orgID, net_name)
+            org_list[dic['id']] = dic['name']
+        orgID = input(f'Please type in the number of the Organization name '
+                      f'that you would like to query {json.dumps(org_list, indent=4)}' "\n")
+        orgName = org_list.get(orgID)
+        loc2 = loc / orgName
+        getlocation2(loc2)
+        getNetworks(orgID, orgName)
 
 
-def getNetworks(orgID, net_name):
+
+def getNetworks(orgID, orgName):
     networks = dashboard.organizations.getOrganizationNetworks(
         orgID, total_pages='all')
     for dic in networks:
-        if dic['name'] == net_name:
-            network_id = dic['id']
-            getAP(network_id)
-        else:
-            print(f'We did not find {net_name} in your organization(s)')
-            sys.exit()
+        if 'wireless' in dic['productTypes']:
+            net_list[dic['id']] = dic['name']
+    for k, v in net_list.items():
+        net_id = k
+        net_name = v
+        getAP(net_id, net_name, orgName)
 
 
-def getAP(network_id):
-    devices = dashboard.networks.getNetworkDevices(network_id)
+
+
+def getAP(net_id, net_name, orgName):
+    devices = dashboard.networks.getNetworkDevices(net_id)
+    ap_list = {}
     for dic in devices:
         model = dic['model'][:2]
         if model == 'MR' or model == 'CW':
-            ap_list[dic['name']] = dic['serial']
-    print(ap_list)
-    getBss(net_name)
+            if dic.get('name') == None:
+                ap_list[dic['mac']] = dic['serial']
+            else:
+                ap_list[dic['name']] = dic['serial']
+    getBss(net_name, orgName, ap_list)
 
 
-def getBss(net_name):
-    bss = f'{loc}/{net_name}.csv'
+def getBss(net_name, orgName, ap_list):
+    bss = f'{loc}/{orgName}/{net_name}.csv'
     with open(bss, mode='w') as f:
         f.write(f"AP Name , SSID Name , Frequency , BSSID" + "\n")
         for k, v in ap_list.items():
@@ -84,18 +100,9 @@ def getBss(net_name):
                 if good is True:
                     f.write(f"{k} , {data['ssidName']} , {data['band']}\
                          , {data['bssid']}" + "\n")
-    print(f'Your file {net_name}.csv has been creeated in {loc}')
-    sys.exit()
+    print(f'Your file {net_name}.csv has been creeated in {loc} / {orgName}')
 
 
 if __name__ == '__main__':
-    try:
-        sys.argv[1]
-    except IndexError:
-        print("Please provide a Network Name")
-        sys.exit()
-    else:
-        net_name = ' '.join(sys.argv[1:])
-        getLocation()
-        getOrgs(net_name)
-        getBss(net_name)
+    getLocation1()
+    getOrgs()


### PR DESCRIPTION
updated script to:
pull all of the BSSID for all networks in an organization and write them to CSV named for the network. It will create folders for "BSSID" and "Organization Name" in ~/Documents
added logic to check 'prodcutTypes' so we do not try and grab information from a network that does not have wireless devices
added logic to use the mac address incase an AP has not been configured with a name
