### PR TITLE
Allow firmware_lock to run once and exit

### DIFF
--- a/firmware_lock/config.yaml
+++ b/firmware_lock/config.yaml
@@ -13,6 +13,10 @@ general:
     
     # If not using applyToAllOrganizations: true, edit the line below to match the name of the organization you want to lock
     organizationName: Big Industries Inc
+
+    # Set runOnce to true to run the script once and exit (suitable for use in a cron job). If set to true, scanIntervalHours
+    # will be ignored
+    runOnce: false
     scanIntervalHours: 6
     
 lockTrain:

--- a/firmware_lock/config.yaml
+++ b/firmware_lock/config.yaml
@@ -6,11 +6,11 @@ general:
     # Your Meraki Dashboard API key. You can find more information about API keys here:
     # https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API
     apiKey: 1234
-    
+
     # Set applyToAllOrganizations to true to apply firmware lock settings to all organizations your API key can access
     # If set to true, organizationName will be ignored
     applyToAllOrganizations: false
-    
+
     # If not using applyToAllOrganizations: true, edit the line below to match the name of the organization you want to lock
     organizationName: Big Industries Inc
 
@@ -18,7 +18,7 @@ general:
     # will be ignored
     runOnce: false
     scanIntervalHours: 6
-    
+
 lockTrain:
     # Use the options below to lock a product type to a specific release train, or leave a value blank to have it unlocked.
     # Valid values:
@@ -32,7 +32,7 @@ lockTrain:
     MT:
     MV:
     MX: stable
-    
+
 lockVersion:
     # Use the options below to lock a product type to a specific release version, or leave a value blank to have it unlocked.
     # If both a lockTrain and a lockVersion configuration is applied for a product type, lockVersion takes precedence
@@ -42,4 +42,3 @@ lockVersion:
     MT:
     MV:
     MX: 15.44
-    

--- a/firmware_lock/firmware_lock.py
+++ b/firmware_lock/firmware_lock.py
@@ -9,26 +9,26 @@ before running this script.
 
 Script syntax, Windows:
     python firmware_lock.py [-c <config_file_name>]
- 
+
 Script syntax, Linux and Mac:
     python3 firmware_lock.py [-c <config_file_name>]
-        
-Optional parameters: 
+
+Optional parameters:
     -c <config_file_name>       Filename of the cofiguration file to be used. If omitted, the default is
                                 "config.yaml"
-                   
+
 Example configuration file:
     https://github.com/meraki/automation-scripts/tree/master/firmware_lock
-                   
+
 Required Python 3 modules:
     requests
     pyyaml
-    
+
 To install these Python 3 modules via pip you can use the following commands:
     pip install requests
     pip install pyyaml
-    
-Depending on your operating system and Python environment, you may need to use commands 
+
+Depending on your operating system and Python environment, you may need to use commands
 "python3" and "pip3" instead of "python" and "pip".
 """
 
@@ -67,7 +67,7 @@ DEVICE_TYPE_MAPPINGS        = {
                                 "MT": "sensor",
                                 "MG": "cellularGateway"
                             }
-                            
+
 PRODUCT_SHORTNAME_MAPPINGS  = {
                                 "appliance"         : "MX",
                                 "switch"            : "MS",
@@ -79,10 +79,10 @@ PRODUCT_SHORTNAME_MAPPINGS  = {
 
 
 
-def merakiRequest(p_apiKey, p_httpVerb, p_endpoint, p_additionalHeaders=None, p_queryItems=None, 
+def merakiRequest(p_apiKey, p_httpVerb, p_endpoint, p_additionalHeaders=None, p_queryItems=None,
         p_requestBody=None, p_verbose=False, p_retry=0):
     #returns success, errors, responseHeaders, responseBody
-    
+
     if p_retry > API_MAX_RETRIES:
         if(p_verbose):
             print("ERROR: Reached max retries")
@@ -92,14 +92,14 @@ def merakiRequest(p_apiKey, p_httpVerb, p_endpoint, p_additionalHeaders=None, p_
     headers = {"Authorization": bearerString}
     if not p_additionalHeaders is None:
         headers.update(p_additionalHeaders)
-        
+
     query = ""
     if not p_queryItems is None:
         query = "?" + urlencode(p_queryItems, True)
     url = API_BASE_URL + p_endpoint + query
-    
+
     verb = p_httpVerb.upper()
-    
+
     session = NoRebuildAuthSession()
 
     try:
@@ -141,41 +141,41 @@ def merakiRequest(p_apiKey, p_httpVerb, p_endpoint, p_additionalHeaders=None, p_
             return False, None, None, None
     except:
         return False, None, None, None
-    
+
     if(p_verbose):
         print(r.status_code)
-    
+
     success         = r.status_code in range (200, 299)
     errors          = None
     responseHeaders = None
     responseBody    = None
-    
+
     if r.status_code == API_STATUS_RATE_LIMIT:
         retryInterval = 2
         if "Retry-After" in r.headers:
             retryInterval = r.headers["Retry-After"]
         if "retry-after" in r.headers:
             retryInterval = r.headers["retry-after"]
-        
+
         if(p_verbose):
             print("INFO: Hit max request rate. Retrying %s after %s seconds" % (p_retry+1, retryInterval))
         time.sleep(int(retryInterval))
-        success, errors, responseHeaders, responseBody = merakiRequest(p_apiKey, p_httpVerb, p_endpoint, p_additionalHeaders, 
+        success, errors, responseHeaders, responseBody = merakiRequest(p_apiKey, p_httpVerb, p_endpoint, p_additionalHeaders,
             p_queryItems, p_requestBody, p_verbose, p_retry+1)
-        return success, errors, responseHeaders, responseBody        
-            
+        return success, errors, responseHeaders, responseBody
+
     try:
         rjson = r.json()
     except:
         rjson = None
-        
+
     if not rjson is None:
         if "errors" in rjson:
             errors = rjson["errors"]
             if(p_verbose):
                 print(errors)
         else:
-            responseBody = rjson  
+            responseBody = rjson
 
     if "Link" in r.headers:
         parsedLinks = utils.parse_header_links(r.headers["Link"])
@@ -184,45 +184,45 @@ def merakiRequest(p_apiKey, p_httpVerb, p_endpoint, p_additionalHeaders=None, p_
                 if(p_verbose):
                     print("Next page:", link["url"])
                 splitLink = link["url"].split("/api/v1")
-                success, errors, responseHeaders, nextBody = merakiRequest(p_apiKey, p_httpVerb, splitLink[1], 
-                    p_additionalHeaders=p_additionalHeaders, 
-                    p_requestBody=p_requestBody, 
+                success, errors, responseHeaders, nextBody = merakiRequest(p_apiKey, p_httpVerb, splitLink[1],
+                    p_additionalHeaders=p_additionalHeaders,
+                    p_requestBody=p_requestBody,
                     p_verbose=p_verbose)
                 if success:
                     if not responseBody is None:
                         responseBody = responseBody + nextBody
                 else:
                     responseBody = None
-    
+
     return success, errors, responseHeaders, responseBody
-    
-    
+
+
 def getOrganizations(apiKey):
     endpoint = "/organizations"
-    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)    
-    return success, errors, response    
-    
+    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)
+    return success, errors, response
+
 def getOrganizationNetworks(apiKey, organizationId):
     endpoint = "/organizations/%s/networks" % organizationId
-    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)    
-    return success, errors, response   
-    
+    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)
+    return success, errors, response
+
 def getOrganizationConfigTemplates(apiKey, organizationId):
     endpoint = "/organizations/%s/configTemplates" % organizationId
-    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)    
-    return success, errors, response 
-    
+    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)
+    return success, errors, response
+
 def getNetworkFirmwareUpgrades(apiKey, networkId):
     endpoint = "/networks/%s/firmwareUpgrades" % networkId
-    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)    
-    return success, errors, response    
-    
+    success, errors, headers, response = merakiRequest(apiKey, "GET", endpoint, p_verbose=FLAG_REQUEST_VERBOSE)
+    return success, errors, response
+
 def updateNetworkFirmwareUpgrade(apiKey, networkId, requestBody):
     endpoint = "/networks/%s/firmwareUpgrades" % networkId
-    success, errors, headers, response = merakiRequest(apiKey, "PUT", endpoint, p_requestBody=requestBody, p_verbose=FLAG_REQUEST_VERBOSE)    
-    return success, errors, response 
-    
- 
+    success, errors, headers, response = merakiRequest(apiKey, "PUT", endpoint, p_requestBody=requestBody, p_verbose=FLAG_REQUEST_VERBOSE)
+    return success, errors, response
+
+
 def log(text, filePath=None):
     logString = "%s -- %s" % (str(datetime.datetime.now())[:19], text)
     print(logString)
@@ -241,58 +241,58 @@ def killScript(reason=None):
     else:
         log("ERROR: %s" % reason)
         sys.exit()
-                       
-           
+
+
 def loadConfig(filename):
     try:
         file = open(filename, "r")
         config = yaml.safe_load(file)
-        file.close()        
+        file.close()
     except:
-        killScript("Unable to load configuration file")        
+        killScript("Unable to load configuration file")
     return config
-    
-    
+
+
 def checkIfDeviceTypesInScope(productTypes, rules):
     for product in productTypes:
         if product in rules:
             return True
     return False
-    
-    
+
+
 def tzLocalOffset():
     currentDateTime = datetime.datetime.fromtimestamp(time.mktime(time.localtime()))
     utcDateTime = datetime.datetime.fromtimestamp(time.mktime(time.gmtime()))
-    
+
     needsMinus = False
     if currentDateTime >= utcDateTime:
         offset = str(currentDateTime - utcDateTime)[:-3]
     else:
         needsMinus = True
         offset = str(utcDateTime - currentDateTime)[:-3]
-        
+
     if len(offset) < 5:
         offset = "0%s" % offset
-        
+
     if needsMinus:
         offset = "-%s" % offset
     else:
         offset = "+%s" % offset
-        
+
     return offset
-    
-    
+
+
 def currentDateTimeTzAware():
     isoString = ("%s%s" % (str(datetime.datetime.now())[:-7], tzLocalOffset())).replace(" ", "T")
     return dateTimeFromIsoString(isoString)
-    
-  
+
+
 def dateTimeFromIsoString(isoString):
     return datetime.datetime.strptime(isoString, "%Y-%m-%dT%H:%M:%S%z")
-    
-    
+
+
 def performScan(apiKey, organizations, enforcementRules):
-    networks = []        
+    networks = []
     for org in organizations:
         success, errors, allNets = getOrganizationNetworks(apiKey, org['id'])
         if not allNets is None:
@@ -304,18 +304,18 @@ def performScan(apiKey, organizations, enforcementRules):
             for template in allTemplates:
                 if checkIfDeviceTypesInScope(template['productTypes'], enforcementRules):
                     networks.append(template)
-                
+
     for net in networks:
         success, errors, firmwareInfo = getNetworkFirmwareUpgrades(apiKey, net['id'])
-        if not success:            
+        if not success:
             log('WARNING: Unable to enforce net "%s"' % net['name'])
         else:
             if 'products' in firmwareInfo:
                 for deviceType in firmwareInfo['products']:
                     if 'nextUpgrade' in firmwareInfo['products'][deviceType]:
                             nextUpgrade = firmwareInfo['products'][deviceType]['nextUpgrade']
-                            if (deviceType in enforcementRules and 
-                                    'toVersion' in nextUpgrade and 
+                            if (deviceType in enforcementRules and
+                                    'toVersion' in nextUpgrade and
                                     'firmware' in nextUpgrade['toVersion']):
                                 flagPushUpdate = False
                                 if 'train' in enforcementRules[deviceType]:
@@ -331,9 +331,9 @@ def performScan(apiKey, organizations, enforcementRules):
                                     oneWeek = datetime.timedelta(weeks=1)
                                     timeRemaining = configuredDateTime - currentDateTime
                                     if(timeRemaining<oneWeek):
-                                        log('Net "%s": Delaying upgrade to version %s' % (net['name'], 
+                                        log('Net "%s": Delaying upgrade to version %s' % (net['name'],
                                             nextUpgrade['toVersion']['shortName']))
-                                        newDateTime = configuredDateTime + oneWeek 
+                                        newDateTime = configuredDateTime + oneWeek
                                         pushBody = {
                                             'products': {
                                                 deviceType: {
@@ -345,35 +345,35 @@ def performScan(apiKey, organizations, enforcementRules):
                                         }
                                         updateNetworkFirmwareUpgrade(apiKey, net['id'], pushBody)
                                     else:
-                                        log('Net "%s": Ignoring upgrade to version %s: Over 1 week left' % (net['name'], 
+                                        log('Net "%s": Ignoring upgrade to version %s: Over 1 week left' % (net['name'],
                                             nextUpgrade['toVersion']['shortName']))
-     
-   
-def main(argv):    
+
+
+def main(argv):
     arg_configFile = DEFAULT_CONFIG_FILE_NAME
-    
+
     try:
         opts, args = getopt.getopt(argv, 'c:h:')
     except getopt.GetoptError:
         killScript()
-        
+
     for opt, arg in opts:
         if opt == '-c':
             arg_configFile = str(arg)
         if opt == '-h':
             killScript()
-                    
+
     log('Using configuration file "%s"' % arg_configFile)
-    
+
     rawConfig = loadConfig(arg_configFile)
-    
+
     flagApplyToAll      = False
     organizationName    = None
     runOnce             = DEFAULT_RUN_ONCE
     scanIntervalHours   = DEFAULT_INTERVAL_HOURS
     enforcementRules    = {}
-    
-    
+
+
     try:
         apiKey = rawConfig['general']['apiKey']
         if 'applyToAllOrganizations' in rawConfig['general']:
@@ -394,18 +394,18 @@ def main(argv):
                 value = rawConfig['lockVersion'][deviceType]
                 if deviceType in DEVICE_TYPE_MAPPINGS and not value is None:
                     # overwrites 'train' enforcement rules. This is intentional
-                    enforcementRules[DEVICE_TYPE_MAPPINGS[deviceType]] = {'version': str(value)}  
+                    enforcementRules[DEVICE_TYPE_MAPPINGS[deviceType]] = {'version': str(value)}
     except:
         killScript('Invalid config file "%s"' % arg_configFile)
-        
+
     log("Using enforcement rules: %s" % enforcementRules)
-    
-    success, errors, allOrgs = getOrganizations(apiKey)    
+
+    success, errors, allOrgs = getOrganizations(apiKey)
     if allOrgs is None:
         killScript("Unable to fetch organizations")
-        
+
     organizations = []
-    
+
     if flagApplyToAll:
         organizations = allOrgs
     else:
@@ -413,10 +413,10 @@ def main(argv):
             if org['name'] == organizationName:
                 organizations.append(org)
                 break
-                    
+
     if len(organizations) == 0:
         killScript("No matching organizations found")
-        
+
     while(True):
         log("Starting next scan...")
         performScan(apiKey, organizations, enforcementRules)
@@ -426,6 +426,6 @@ def main(argv):
         else:
             print("Exiting.")
             sys.exit()
-    
+
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/firmware_lock/firmware_lock.py
+++ b/firmware_lock/firmware_lock.py
@@ -57,6 +57,7 @@ API_BASE_URL                = "https://api.meraki.com/api/v1"
 
 DEFAULT_CONFIG_FILE_NAME    = "config.yaml"
 DEFAULT_INTERVAL_HOURS      = 24
+DEFAULT_RUN_ONCE            = False
 
 DEVICE_TYPE_MAPPINGS        = {
                                 "MX": "appliance",
@@ -368,6 +369,7 @@ def main(argv):
     
     flagApplyToAll      = False
     organizationName    = None
+    runOnce             = DEFAULT_RUN_ONCE
     scanIntervalHours   = DEFAULT_INTERVAL_HOURS
     enforcementRules    = {}
     
@@ -378,6 +380,8 @@ def main(argv):
             flagApplyToAll = rawConfig['general']['applyToAllOrganizations']
         if 'organizationName' in rawConfig['general']:
             organizationName = rawConfig['general']['organizationName']
+        if 'runOnce' in rawConfig['general']:
+            runOnce = rawConfig['general']['runOnce']
         if 'scanIntervalHours' in rawConfig['general']:
             scanIntervalHours = rawConfig['general']['scanIntervalHours']
         if 'lockTrain' in rawConfig:
@@ -416,8 +420,12 @@ def main(argv):
     while(True):
         log("Starting next scan...")
         performScan(apiKey, organizations, enforcementRules)
-        log("Next scan in %s hours" % scanIntervalHours)
-        time.sleep(scanIntervalHours * 3600)
+        if not runOnce:
+            log("Next scan in %s hours" % scanIntervalHours)
+            time.sleep(scanIntervalHours * 3600)
+        else:
+            print("Exiting.")
+            sys.exit()
     
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
Currently the `firmware_lock` script operates on a loop, using the `scanIntervalHours` config setting to determine how often a scan is performed (default is every 24 hours).

This PR modifies firmware_lock to add a `runOnce` setting that overrides scanIntervalHours, allowing the script to run once and exit. This is useful for one-time manual runs, or allowing the script to be used in a cron job.