### PR TITLE
Update requirements.txt for backup_configs

### DIFF
--- a/backup_configs/requirements.txt
+++ b/backup_configs/requirements.txt
@@ -1,3 +1,3 @@
 meraki==1.40.1
-pyyaml==5.4
-requests==2.32.0
+pyyaml==6.0.2
+requests==2.32.2


### PR DESCRIPTION
PyYAML 5.4 was failing to build on Python 3.10 due to a Setuptools deprecation warning.
Requests 2.32.0 was yanked "due to conflicts with CVE-2024-35195 mitigation".

```
  × Failed to build `pyyaml==5.4`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stdout]
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt

      [stderr]
      /Users/jason/.cache/uv/builds-v0/.tmpz9du3M/lib/python3.10/site-packages/setuptools/dist.py:759:
      SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license
      expression:

              License :: OSI Approved :: MIT License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
      for details.
              ********************************************************************************

      !!
        self._finalize_license_expression()
```

Thanks for the helpful scripts!